### PR TITLE
Fixing weather icon missing

### DIFF
--- a/Super Flat Remix/apps/scalable/org.gnome.Weather.svg
+++ b/Super Flat Remix/apps/scalable/org.gnome.Weather.svg
@@ -1,0 +1,1 @@
+org.gnome.Weather.Application.svg

--- a/Super Flat Remix/apps/scalable/sun-java-jdk8.svg
+++ b/Super Flat Remix/apps/scalable/sun-java-jdk8.svg
@@ -1,0 +1,1 @@
+java.svg

--- a/Super Flat Remix/apps/scalable/sun-javaws-jdk8.svg
+++ b/Super Flat Remix/apps/scalable/sun-javaws-jdk8.svg
@@ -1,0 +1,1 @@
+java.svg

--- a/Super Flat Remix/apps/scalable/sun-jcontrol-jdk8.svg
+++ b/Super Flat Remix/apps/scalable/sun-jcontrol-jdk8.svg
@@ -1,0 +1,1 @@
+java.svg


### PR DESCRIPTION
Create soft link as "org.gnome.Weather" from "org.gnome.Weather.Application"