### PR TITLE
org.gnome.tweaks: link to gnome-tweak-tools (GNOME 3.28 change)

### DIFF
--- a/Flat-Remix-Dark/apps/scalable/org.gnome.tweaks.svg
+++ b/Flat-Remix-Dark/apps/scalable/org.gnome.tweaks.svg
@@ -1,0 +1,1 @@
+gnome-tweak-tool.svg

--- a/Flat-Remix-Dark/apps/symbolic/org.gnome.tweaks-symbolic.svg
+++ b/Flat-Remix-Dark/apps/symbolic/org.gnome.tweaks-symbolic.svg
@@ -1,0 +1,1 @@
+gnome-tweak-tool-symbolic.svg

--- a/Flat-Remix-Light/apps/scalable/org.gnome.tweaks.svg
+++ b/Flat-Remix-Light/apps/scalable/org.gnome.tweaks.svg
@@ -1,0 +1,1 @@
+gnome-tweak-tool.svg

--- a/Flat-Remix-Light/apps/symbolic/org.gnome.tweaks-symbolic.svg
+++ b/Flat-Remix-Light/apps/symbolic/org.gnome.tweaks-symbolic.svg
@@ -1,0 +1,1 @@
+gnome-tweak-tool-symbolic.svg

--- a/Flat-Remix/apps/scalable/org.gnome.tweaks.svg
+++ b/Flat-Remix/apps/scalable/org.gnome.tweaks.svg
@@ -1,0 +1,1 @@
+gnome-tweak-tool.svg

--- a/Flat-Remix/apps/symbolic/org.gnome.tweaks-symbolic.svg
+++ b/Flat-Remix/apps/symbolic/org.gnome.tweaks-symbolic.svg
@@ -1,0 +1,1 @@
+gnome-tweak-tool-symbolic.svg


### PR DESCRIPTION
In the new GNOME version 3.28, GNOME Tweak Tools is renamed as GNOME Tweaks, along with its icons, from `gnome-tweak-tools`, to `org.gnome.tweaks`.